### PR TITLE
updateMember OT298-72

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/MemberController.java
+++ b/src/main/java/com/alkemy/ong/controller/MemberController.java
@@ -5,10 +5,7 @@ import com.alkemy.ong.service.IMemberService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -23,5 +20,14 @@ public class MemberController {
     public ResponseEntity<MemberDTO> save(@Valid @RequestBody MemberDTO dto){
         MemberDTO savedMember = memberService.save(dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(savedMember);
+    }
+    @PutMapping("/{id}")
+    public ResponseEntity<MemberDTO> update(@Valid @PathVariable("id") Long id, @RequestBody MemberDTO dto) {
+
+        MemberDTO memberdtoupdated = memberService.update(id,dto);
+
+        return ResponseEntity.ok().body(memberdtoupdated);
+
+
     }
 }

--- a/src/main/java/com/alkemy/ong/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/alkemy/ong/exception/ControllerExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import javax.persistence.EntityNotFoundException;
 import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
@@ -134,6 +135,18 @@ public class ControllerExceptionHandler extends ResponseEntityExceptionHandler {
     }
     @ExceptionHandler(value = {IOException.class})
     protected ResponseEntity<ErrorMessage> handleIOExceptionException (IOException ex,
+                                                                            WebRequest request){
+        ErrorMessage message = new ErrorMessage(
+                HttpStatus.NOT_FOUND.value(),
+                new Date(),
+                ex.getMessage(),
+                request.getDescription(false));
+
+        return new ResponseEntity<>(message, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(value = {EntityNotFoundException.class})
+    protected ResponseEntity<ErrorMessage> handleEntityNotFoundException (EntityNotFoundException ex,
                                                                             WebRequest request){
         ErrorMessage message = new ErrorMessage(
                 HttpStatus.NOT_FOUND.value(),

--- a/src/main/java/com/alkemy/ong/service/IMemberService.java
+++ b/src/main/java/com/alkemy/ong/service/IMemberService.java
@@ -5,4 +5,6 @@ import com.alkemy.ong.dto.MemberDTO;
 public interface IMemberService {
 
     MemberDTO save(MemberDTO dto);
+
+    MemberDTO update(Long id,MemberDTO dto);
 }

--- a/src/main/java/com/alkemy/ong/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/MemberServiceImpl.java
@@ -43,7 +43,7 @@ public class MemberServiceImpl implements IMemberService {
 
         try {
 
-            VerifiedNullData(dto, member);
+            verifiedNullData(dto, member);
 
 
             memberRepository.save(member);
@@ -61,7 +61,7 @@ public class MemberServiceImpl implements IMemberService {
     /*Comprueba que los datos que se van a actualizar no pisen a los que no se actualizan,si no, los va retorna nulos
      o no actualiza nada en la base de datos*/
 
-    private static void VerifiedNullData(MemberDTO dto, Member member) {
+    private static void verifiedNullData(MemberDTO dto, Member member) {
         if(!StringUtils.hasLength(dto.getName())){
             member.setName(member.getName());
         }else{

--- a/src/main/java/com/alkemy/ong/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/MemberServiceImpl.java
@@ -1,15 +1,22 @@
 package com.alkemy.ong.service.impl;
 
 import com.alkemy.ong.dto.MemberDTO;
+import com.alkemy.ong.exception.EntityNotSavedException;
 import com.alkemy.ong.mapper.MemberMapper;
 import com.alkemy.ong.model.Member;
 import com.alkemy.ong.repository.MemberRepository;
 import com.alkemy.ong.service.IMemberService;
+import org.aspectj.bridge.Message;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
+import javax.persistence.EntityNotFoundException;
 import javax.transaction.Transactional;
+import java.util.Locale;
+import java.util.Optional;
 
 @Service
 public class MemberServiceImpl implements IMemberService {
@@ -20,10 +27,86 @@ public class MemberServiceImpl implements IMemberService {
     @Autowired
     private MemberMapper memberMapper;
 
+    @Autowired
+    private MessageSource message;
+
     @Transactional
-    public MemberDTO save(MemberDTO dto){
-            Member member = memberMapper.memberDTOToMember(dto);
-            Member savedMember = memberRepository.save(member);
-            return memberMapper.memberToMemberDTO(savedMember);
+    public MemberDTO save(MemberDTO dto) {
+        Member member = memberMapper.memberDTOToMember(dto);
+        Member savedMember = memberRepository.save(member);
+        return memberMapper.memberToMemberDTO(savedMember);
     }
+
+    @Override
+    public MemberDTO update(Long id, MemberDTO dto) {
+            Member member = getMemberEntityById(id);
+
+        try {
+
+            VerifiedNullData(dto, member);
+
+
+            memberRepository.save(member);
+
+        } catch (EntityNotSavedException ense) {
+
+            throw new EntityNotSavedException(message.getMessage("member.notSaved", null, Locale.US));
+
+        }
+
+
+        return memberMapper.memberToMemberDTO(member);
+    }
+
+    /*Comprueba que los datos que se van a actualizar no pisen a los que no se actualizan,si no, los va retorna nulos
+     o no actualiza nada en la base de datos*/
+
+    private static void VerifiedNullData(MemberDTO dto, Member member) {
+        if(!StringUtils.hasLength(dto.getName())){
+            member.setName(member.getName());
+        }else{
+            member.setName(dto.getName());
+        }
+
+
+        if(!StringUtils.hasLength(dto.getImage())){
+            member.setImage(member.getImage());
+        }else{
+            member.setImage(dto.getImage());
+        }
+
+        if(!StringUtils.hasLength(dto.getDescription())){
+            member.setDescription(member.getDescription());
+        }else{
+            member.setDescription(dto.getDescription());
+        }
+
+        if(!StringUtils.hasLength(dto.getFacebookUrl())){
+            member.setFacebookUrl(member.getFacebookUrl());
+        }else{
+            member.setFacebookUrl(dto.getFacebookUrl());
+        }
+
+        if(!StringUtils.hasLength(dto.getInstagramUrl())){
+            member.setInstagramUrl(member.getInstagramUrl());
+        }else{
+            member.setInstagramUrl(dto.getInstagramUrl());
+        }
+
+        if(!StringUtils.hasLength(dto.getLinkedinUrl())){
+            member.setLinkedinUrl(member.getLinkedinUrl());
+        }else{
+            member.setLinkedinUrl(dto.getLinkedinUrl());
+        }
+    }
+
+    private Member getMemberEntityById(Long id) {
+        Optional<Member> member = memberRepository.findById(id);
+        if (!member.isPresent()) {
+            throw new EntityNotFoundException(message.getMessage("member.notFound", null, Locale.US));
+        }
+
+        return member.get();
+    }
+
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -51,4 +51,6 @@ organization.notFound = There's no organization with the given id
 
 testimonial.notFound = There's no testimonial with the given id
 
+member.notFound=Member not found with the given ID
 
+member.notSaved=Member couldn't be updated


### PR DESCRIPTION
Sin el metodo verifiedNullData ,en algunos casos que se actualiza solo un parametro ,devolvia nulo los demas ,o no actualizaba directamente el parametro.
Ahora sí se actualiza uno solo ,los demas quedan con sus anteriores datos.

Ejemplo pagina nueva de facebook : 
No actualizaba en la base de datos ,quedaba la antigua 
o si al momento de crearse el miembro no se pasaba por parametro la pagina de facebook , quedaba vacia.