### PR TITLE
Feature/OT298-89

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/controller/TestimonialController.java
@@ -1,5 +1,6 @@
 package com.alkemy.ong.controller;
 
+import com.alkemy.ong.documentation.ITestimonialController;
 import com.alkemy.ong.dto.TestimonialDTO;
 import com.alkemy.ong.exception.ResourceNotFoundException;
 import com.alkemy.ong.service.ITestimonialService;
@@ -18,7 +19,7 @@ import static com.alkemy.ong.util.Constants.Endpoints.*;
 
 @RestController
 @RequestMapping(TESTIMONIAL)
-public class TestimonialController {
+public class TestimonialController implements ITestimonialController{
     
     @Autowired
     private ITestimonialService service;

--- a/src/main/java/com/alkemy/ong/documentation/ITestimonialController.java
+++ b/src/main/java/com/alkemy/ong/documentation/ITestimonialController.java
@@ -1,0 +1,62 @@
+package com.alkemy.ong.documentation;
+
+import com.alkemy.ong.dto.TestimonialDTO;
+import com.alkemy.ong.exception.ResourceNotFoundException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import java.util.Map;
+
+@Tag(name = "Testimonial Controller", description = "CRUD of testimonials")
+public interface ITestimonialController {
+
+        @Operation(summary = "Get paginated testimonials" , description = "testimonial.get.page.description")
+        @ApiResponses(value = {
+                @ApiResponse(responseCode = "200", description = "Resources fetched successfully",
+                        content = {@Content(schema = @Schema(implementation = TestimonialDTO.class))}),
+                @ApiResponse(responseCode = "400", description = "invalid.Page", content = @Content),
+                @ApiResponse(responseCode = "403", description = "user.notAuthenticated", content = @Content),
+                @ApiResponse(responseCode = "404", description = "page.NotFound", content = @Content),
+                @ApiResponse(responseCode = "500", description = "unable.toFetch", content = @Content)
+        })
+        ResponseEntity<Map<String, Object>> getTestimonialPage(@Parameter(description = "Number of page")Integer page,
+                                                               @Parameter(description = "Pageable object")Pageable pageable);
+
+        @Operation(summary = "Create a new testimonial" , description = "testimonial.save.description")
+        @ApiResponses(value = {
+                @ApiResponse(responseCode = "200", description = "Testimonial created successfully", content = @Content),
+                @ApiResponse(responseCode = "403", description = "not.AdminRole", content = @Content),
+                @ApiResponse(responseCode = "500", description = "unable.toSave", content = @Content)
+        })
+        ResponseEntity<?> save(@Parameter(description = "Testimonial DTO to save a new testimonial")
+                               TestimonialDTO dto) throws Exception;
+
+        @Operation(summary = "Update a Testimonial" , description = "testimonial.update.description")
+        @ApiResponses(value = {
+                @ApiResponse(responseCode = "200", description = "Successfully updated",
+                        content = {@Content(mediaType = "application/json",
+                        schema = @Schema(implementation = TestimonialDTO.class))}),
+                @ApiResponse(responseCode = "403", description = "not.AdminRole", content = @Content),
+                @ApiResponse(responseCode = "404", description = "testimonial.notFound", content = @Content),
+                @ApiResponse(responseCode = "500", description = "unable.toUpdate", content = @Content)
+        })
+        ResponseEntity<TestimonialDTO> updateTestimonial(@Parameter(description = "Testimonial Id to update") Long id,
+                                                         @Parameter(description = "Testimonial DTO to update testimonial data")
+                                                         TestimonialDTO dto);
+
+        @Operation(summary = "Soft delete a testimonial" , description = "testimonial.delete.description")
+        @ApiResponses(value = {
+                @ApiResponse(responseCode = "204", description = "Successfully deleted", content = @Content),
+                @ApiResponse(responseCode = "403", description = "not.AdminRole", content = @Content),
+                @ApiResponse(responseCode = "404", description = "testimonial.notFound", content = @Content),
+                @ApiResponse(responseCode = "500", description = "unable.toDelete", content = @Content)
+        })
+        ResponseEntity<Void> delete(@Parameter(description = "Testimonial id to delete") Long id) throws ResourceNotFoundException;
+
+}

--- a/src/main/java/com/alkemy/ong/security/config/AppSecurity.java
+++ b/src/main/java/com/alkemy/ong/security/config/AppSecurity.java
@@ -48,6 +48,7 @@ public class AppSecurity extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers(API_UI_ANTMATCHER, API_DESCRIPTION_ANTMATCHER).permitAll()
                 .and().authorizeRequests()
+                .antMatchers("/v2/api-docs", "/v3/api-docs","/swagger-ui.html", "api/docs").permitAll()
                 .antMatchers("/auth/*").permitAll()
                 .antMatchers(HttpMethod.GET, USER).hasAnyAuthority(ROLE_ADMIN)
                 .antMatchers(HttpMethod.PATCH, USER_UPDATE).hasAnyAuthority(ALL_ROLES)

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -81,6 +81,17 @@ invalid.Page = Page number must be non-negative
 
 access.denied=Access Denied
 
+not.AdminRole = User not authenticated as Admin
+unable.toSave = Unable to save the entity
+unable.toUpdate = Unable to update the entity
+unable.toDelete = Unable to delete the entity
+unable.toFetch= Unable to fetch testimonials
+
+testimonial.save.description = An Admin user can create a new testimonial
+testimonial.update.description = An Admin user can update a testimonial
+testimonial.delete.description = An Admin user can delete a testimonial
+testimonial.get.page.description = A user can fetch paginated testimonials
+
 # api documentation
 
 api.title=ONG API


### PR DESCRIPTION
- Added documentation to Testimonials endpoints

Evidence:
General view:
![testimonial controller swagger](https://user-images.githubusercontent.com/78282120/195409635-a9734e0a-8395-4062-bc81-5ace18ba7cb5.png)

Save:
![save testimonial controller swagger](https://user-images.githubusercontent.com/78282120/195409781-600b5ab4-b476-45cd-9531-bd636e13f86d.png)

Delete:
![delete testimonial controller swagger](https://user-images.githubusercontent.com/78282120/195409820-0e16c7a6-98a6-43fc-ab4c-8154b2ed0153.png)

Update:
![update1 testimonial controller swagger](https://user-images.githubusercontent.com/78282120/195410074-5c01e035-082a-456a-9d68-ca4e16072df7.png)

Get:
![get1 testimonial controller swagger](https://user-images.githubusercontent.com/78282120/195410132-db2472ce-d42f-4f83-8545-aedfd8d18c89.png)
